### PR TITLE
use ExecutionMethod::POST() instead of a string

### DIFF
--- a/src/Logger.php
+++ b/src/Logger.php
@@ -3,6 +3,7 @@
 namespace SSAWeb\AppwriteLogger;
 
 use Appwrite\Services\Functions;
+use Appwrite\Enums\ExecutionMethod;
 
 class Logger {
     private readonly string $cid;
@@ -25,7 +26,7 @@ class Logger {
             'fnLogger',
             json_encode($body),
             async: true,
-            method: 'POST',
+            method: ExecutionMethod::POST(),
             headers: ['content-type' => 'application/json']
         );
     }


### PR DESCRIPTION
This pull request includes changes to the `src/Logger.php` file, primarily aimed at improving code readability and maintainability. The changes involve the introduction of an enumeration for execution methods and a minor modification to the `log` function.

Here are the key changes:

* [`src/Logger.php`](diffhunk://#diff-d6a00c7572381de9ee69f8f73e7fa7e41073a19467332fb28017c9b1a69bcbdbR6): Imported the `ExecutionMethod` enumeration from the `Appwrite\Enums` namespace. This change improves code readability by replacing hardcoded string values with meaningful enumeration names.
* `public function log(string $message, array $params = [], array $tags = [])` in `src/Logger.php`: Replaced the hardcoded 'POST' string with `ExecutionMethod::POST()`. This change enhances code maintainability and reduces the risk of typos or inconsistencies.